### PR TITLE
BLD: Fixes build error by including numpy in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,9 +42,11 @@ with open(path.join(here, 'README.md'), 'r') as f:
 if __name__ == "__main__":
     from setuptools import setup, find_packages
     from Cython.Build import cythonize
+    import numpy
 
     setup(name='numpy-dispatch',
           ext_modules=cythonize("numpy_dispatch/_dispatching.pyx"),
+          include_dirs=[numpy.get_include()],
           version=get_version(),
           description='Generic dispatching for array-libraries',
           long_description=long_description,


### PR DESCRIPTION
This fixes the following build error when trying to compile `numpy_dispatch/_dispatching.c`:

```bash
numpy_dispatch/_dispatching.c:611:10: fatal error: 'numpy/arrayobject.h' file not found
#include "numpy/arrayobject.h"
         ^~~~~~~~~~~~~~~~~~~~~
1 error generated.
```