### PR TITLE
Add a pyproject.toml file

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[build-system]
+requires = ["setuptools", "wheel", "cython", "numpy"]


### PR DESCRIPTION
This makes it possible to directly install numpy_dispatch with pip, even if cython was not already installed.

(Thank you everyone who works on Python build tools for making this possible!)

ping @seberg !